### PR TITLE
Added lower() after strip()

### DIFF
--- a/src/censor_parser.py
+++ b/src/censor_parser.py
@@ -38,7 +38,7 @@ def parse_cncpo_list(infile):
             i = 1
             continue
         if row is not None and len(row)>0 :
-            data = row[1].strip()
+            data = row[1].strip().lower()
             if len(data) > 0:
                 black_list.append(data)
     csvfile.close()
@@ -52,7 +52,7 @@ def parse_aams_list(infile):
     fp = open(infile)
     line = fp.readline()
     while line:
-        data = line.strip()
+        data = line.strip().lower()
         if len(data) > 0:
                 black_list.append(data)
         line = fp.readline()
@@ -67,7 +67,7 @@ def parse_manual_list(infile):
     fp = open(infile)
     line = fp.readline()
     while line:
-        data = line.strip()
+        data = line.strip().lower()
         if len(data) > 0:
             black_list.append(data)
         line = fp.readline()


### PR DESCRIPTION
This will prevent duplicates due to duplicated domains written with capital letter (eg: www.Slotland.com / www.slotland.com on AAMS list)