### PR TITLE
Add automatic AGCOM list handling

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,4 @@ decorator==5.1.1
 six==1.16.0
 validators==0.18.2
 webdriver_manager==3.8.4
-selenium==4.5.0
-packaging==21.3
+beautifulsoup4==4.11.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ six==1.16.0
 validators==0.18.2
 webdriver_manager==3.8.4
 selenium==4.5.0
+packaging==21.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 decorator==5.1.1
 six==1.16.0
 validators==0.18.2
-webdriver_manager==3.8.4
 beautifulsoup4==4.11.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 decorator==5.1.1
 six==1.16.0
 validators==0.18.2
+webdriver_manager==3.8.4
+selenium==4.5.0

--- a/src/censor_parser.py
+++ b/src/censor_parser.py
@@ -9,7 +9,7 @@ options = None
 default_blackhole = '127.0.0.1'
 default_bind_block_zonefile = '/etc/bind/zones/dns_block_zone.zone'
 out_format_list = ['unbound', 'bind']
-in_format_list = ['cncpo', 'aams', 'admt', 'manuale']
+in_format_list = ['cncpo', 'aams', 'admt', 'agcom', 'manuale']
 
 def write_unbound_list(outfile, blacklist, blackhole):
     fp = open(outfile, 'w')
@@ -49,6 +49,22 @@ def parse_cncpo_list(infile):
 
 
 def parse_aams_list(infile):
+    black_list = list()
+    fp = open(infile)
+    line = fp.readline()
+    while line:
+        data = line.strip().lower()
+        if len(data) > 0:
+                black_list.append(data)
+        line = fp.readline()
+    fp.close()
+    # Eliminazione dei duplicati
+    bl2 = list(set(black_list))
+    return bl2
+
+
+
+def parse_agcom_list(infile):
     black_list = list()
     fp = open(infile)
     line = fp.readline()
@@ -153,6 +169,8 @@ def main():
         dns_bl = parse_aams_list(options.in_file)
     elif options.in_format == 'admt':
         dns_bl = parse_aams_list(options.in_file)
+    elif options.in_format == 'agcom':
+        dns_bl = parse_agcom_list(options.in_file)
     elif options.in_format == 'manuale':
         dns_bl = parse_manual_list(options.in_file)
     else:

--- a/src/download_agcom.py
+++ b/src/download_agcom.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-import requests, optparse, urllib3
+import requests, optparse
 from bs4 import BeautifulSoup
 
 def main():

--- a/src/download_agcom.py
+++ b/src/download_agcom.py
@@ -22,9 +22,10 @@ def main():
         parser.error("Numero di argomenti non corretto")
 
     service = Service(executable_path=ChromeDriverManager().install())
-
+    op = webdriver.ChromeOptions()
+    op.add_argument('--headless')
     url = "https://www.agcom.it/provvedimenti-a-tutela-del-diritto-d-autore"
-    driver = webdriver.Chrome(service=service)
+    driver = webdriver.Chrome(service=service, options=op)
     driver.get(url)
     lastDetermina = driver.find_element(By.PARTIAL_LINK_TEXT, "Determina").get_attribute('href')
     driver.get(lastDetermina)

--- a/src/download_agcom.py
+++ b/src/download_agcom.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+
+import requests, optparse
+from selenium import webdriver
+from selenium.webdriver.common.by import By
+from webdriver_manager.chrome import ChromeDriverManager
+from selenium.webdriver.chrome.service import Service
+
+
+def main():
+    global options
+
+    # Elaborazione argomenti della linea di comando
+    usage = "usage: %prog [options] arg"
+    parser = optparse.OptionParser(usage)
+    parser.add_option("-o", "--output", dest="out_file", help="File di output generato")
+
+    (options, args) = parser.parse_args()
+    if len(args) == 1:
+        parser.error("Numero di argomenti non corretto")
+    if (options.out_file is None):
+        parser.error("Numero di argomenti non corretto")
+
+    service = Service(executable_path=ChromeDriverManager().install())
+
+    url = "https://www.agcom.it/provvedimenti-a-tutela-del-diritto-d-autore"
+    driver = webdriver.Chrome(service=service)
+    driver.get(url)
+    lastDetermina = driver.find_element(By.PARTIAL_LINK_TEXT, "Determina").get_attribute('href')
+    driver.get(lastDetermina)
+    allegatoB = driver.find_element(By.LINK_TEXT, "Allegato B").get_attribute('href')
+    driver.quit()
+
+    response = requests.get(allegatoB)
+    with open(options.out_file,'wb') as f:
+        f.write(response.content)
+
+if __name__ == '__main__':
+    main()

--- a/src/update_agcom.sh
+++ b/src/update_agcom.sh
@@ -16,7 +16,7 @@ fi
 PARSER_OPTS="-i ${LIST_FILE} -o ${LIST_OUT} -f ${OUTPUT_FORMAT} -d ${LIST_TYPE} -b ${BLACKHOLE}"
 
 ## downloading ###############################################################
-${python3 download_agcom.py -o ${LIST_FILE}}
+$(python3 download_agcom.py -o ${LIST_FILE})
 
 ## parsing ###################################################################
 ${PARSER_BIN} ${PARSER_OPTS}

--- a/src/update_agcom.sh
+++ b/src/update_agcom.sh
@@ -1,0 +1,22 @@
+#!/bin/sh -e
+
+. $(dirname "${0}")/censorship_params.sh
+
+LIST_FILE="${TMP_DL_DIR}/blacklist_agcom.txt"
+LIST_OUT="${UNBOUND_CONF_DIR}/db.blacklist_agcom.conf"
+LIST_TYPE="agcom"
+BLACKHOLE="127.0.0.1"
+
+if [ ! -d "${TMP_DL_DIR}" ]
+then
+   echo "Missing temp download dir ${TMP_DL_DIR}"
+   mkdir "${TMP_DL_DIR}"
+fi
+
+PARSER_OPTS="-i ${LIST_FILE} -o ${LIST_OUT} -f ${OUTPUT_FORMAT} -d ${LIST_TYPE} -b ${BLACKHOLE}"
+
+## downloading ###############################################################
+"download_agcom.py -o ${LIST_FILE}"
+
+## parsing ###################################################################
+${PARSER_BIN} ${PARSER_OPTS}

--- a/src/update_agcom.sh
+++ b/src/update_agcom.sh
@@ -16,7 +16,7 @@ fi
 PARSER_OPTS="-i ${LIST_FILE} -o ${LIST_OUT} -f ${OUTPUT_FORMAT} -d ${LIST_TYPE} -b ${BLACKHOLE}"
 
 ## downloading ###############################################################
-"download_agcom.py -o ${LIST_FILE}"
+${python3 download_agcom.py -o ${LIST_FILE}}
 
 ## parsing ###################################################################
 ${PARSER_BIN} ${PARSER_OPTS}


### PR DESCRIPTION
Using simple python libraries such as `requests` and `beautifulsoup4` we can scrape the [agcom official list of "Determine"](https://www.agcom.it/provvedimenti-a-tutela-del-diritto-d-autore), get the "AllegatoB" download url and treat it like yet another plain text blacklist file.