### PR TITLE
Fix download AGCOM list and improvements

### DIFF
--- a/src/censorship_params.sh
+++ b/src/censorship_params.sh
@@ -6,7 +6,14 @@ TMP_DL_DIR="${ROOT_DIR}/tmp"
 PARSER_BIN="${ROOT_DIR}/censor_parser.py"
 WGET_BIN=$(which wget)
 
-BLACKHOLE="127.0.0.1" #Replace with the chosen IP address
+MANUAL_LIST_FILE="${ROOT_DIR}/blacklist_manual.txt"
+
+BLACKHOLE_CNCPO="127.0.0.1" #Replace with the chosen IP address for the CNCPO list
+BLACKHOLE_AGCOM="127.0.0.1" #Replace with the chosen IP address for the AGCOM list
+BLACKHOLE_AAMS="217.175.53.72" #Replace, if changed, with the chosen IP address for the AAMS list
+BLACKHOLE_ADMT="217.175.53.228" #Replace, if changed, with the chosen IP address for the ADMT list
+BLACKHOLE_MANUAL="127.0.0.1" #Replace with the chosen IP address for the Manual list
+
 OUTPUT_FORMAT="unbound"  # Replace to "bind" or to "unbound"
 
 # Unbound params

--- a/src/update_aams.sh
+++ b/src/update_aams.sh
@@ -6,7 +6,6 @@ LIST_URL="https://www1.adm.gov.it/files_siti_inibiti/elenco_siti_inibiti.txt"
 LIST_FILE="${TMP_DL_DIR}/blacklist_aams.txt"
 LIST_OUT="${UNBOUND_CONF_DIR}/db.blacklist_aams.conf"
 LIST_TYPE="aams"
-BLACKHOLE="217.175.53.72"
 
 WGET_CERTS=""
 WGET_OPTS="${WGET_CERTS} --no-check-certificate"
@@ -17,7 +16,7 @@ then
    mkdir "${TMP_DL_DIR}"
 fi
 
-PARSER_OPTS="-i ${LIST_FILE} -o ${LIST_OUT} -f ${OUTPUT_FORMAT} -d ${LIST_TYPE} -b ${BLACKHOLE}"
+PARSER_OPTS="-i ${LIST_FILE} -o ${LIST_OUT} -f ${OUTPUT_FORMAT} -d ${LIST_TYPE} -b ${BLACKHOLE_AAMS}"
 
 ##############################################################################
 # be verbose when stdout is a tty

--- a/src/update_admt.sh
+++ b/src/update_admt.sh
@@ -6,7 +6,6 @@ LIST_URL="https://www1.adm.gov.it/files_siti_inibiti_tabacchi/elenco_siti_inibit
 LIST_FILE="${TMP_DL_DIR}/blacklist_admt.txt"
 LIST_OUT="${UNBOUND_CONF_DIR}/db.blacklist_admt.conf"
 LIST_TYPE="admt"
-BLACKHOLE="217.175.53.228"
 
 WGET_CERTS=""
 WGET_OPTS="${WGET_CERTS} --no-check-certificate"
@@ -17,7 +16,7 @@ then
    mkdir "${TMP_DL_DIR}"
 fi
 
-PARSER_OPTS="-i ${LIST_FILE} -o ${LIST_OUT} -f ${OUTPUT_FORMAT} -d ${LIST_TYPE} -b ${BLACKHOLE}"
+PARSER_OPTS="-i ${LIST_FILE} -o ${LIST_OUT} -f ${OUTPUT_FORMAT} -d ${LIST_TYPE} -b ${BLACKHOLE_ADMT}"
 
 ##############################################################################
 # be verbose when stdout is a tty

--- a/src/update_agcom.sh
+++ b/src/update_agcom.sh
@@ -1,11 +1,10 @@
-#!/bin/sh -e
+#!/bin/sh
 
 . $(dirname "${0}")/censorship_params.sh
 
 LIST_FILE="${TMP_DL_DIR}/blacklist_agcom.txt"
 LIST_OUT="${UNBOUND_CONF_DIR}/db.blacklist_agcom.conf"
 LIST_TYPE="agcom"
-BLACKHOLE="127.0.0.1"
 
 if [ ! -d "${TMP_DL_DIR}" ]
 then
@@ -13,10 +12,16 @@ then
    mkdir "${TMP_DL_DIR}"
 fi
 
-PARSER_OPTS="-i ${LIST_FILE} -o ${LIST_OUT} -f ${OUTPUT_FORMAT} -d ${LIST_TYPE} -b ${BLACKHOLE}"
+PARSER_OPTS="-i ${LIST_FILE} -o ${LIST_OUT} -f ${OUTPUT_FORMAT} -d ${LIST_TYPE} -b ${BLACKHOLE_AGCOM}"
 
 ## downloading ###############################################################
-$(python3 $(dirname "${0}")/download_agcom.py -o ${LIST_FILE})
+python3 $(dirname "${0}")/download_agcom.py -o ${LIST_FILE}
+returnCode=$?
 
+if [ $returnCode -ne 0 ];then
+    echo "Couldn't download latest AGCOM list"
+    exit 1
+else
 ## parsing ###################################################################
-${PARSER_BIN} ${PARSER_OPTS}
+   ${PARSER_BIN} ${PARSER_OPTS}
+fi

--- a/src/update_blacklists.sh
+++ b/src/update_blacklists.sh
@@ -5,6 +5,7 @@
 ${ROOT_DIR}/update_cncpo.sh || true
 ${ROOT_DIR}/update_aams.sh  || true
 ${ROOT_DIR}/update_admt.sh  || true
+${ROOT_DIR}/update_agcom.sh  || true
 ${ROOT_DIR}/update_manual.sh  || true
 
 /usr/local/etc/rc.d/unbound reload # or `rndc reload` according to your mileage

--- a/src/update_cncpo.sh
+++ b/src/update_cncpo.sh
@@ -8,12 +8,9 @@ LIST_OUT="${UNBOUND_CONF_DIR}/db.blacklist_cncpo.conf"
 LIST_TYPE="cncpo"
 
 WGET_CERT_FILE="${ROOT_DIR}/cncpo.pem"
-WGET_CERT_KEY="${ROOT_DIR}/cncpo.key"
-WGET_CERT_CA="${ROOT_DIR}/cncpo-ca.pem"
-WGET_CERTS="--certificate=${WGET_CERT_FILE} --private-key=${WGET_CERT_KEY} --ca-certificate=${WGET_CERT_CA}"
+WGET_CERTS="--certificate=${WGET_CERT_FILE}"
 WGET_OPTS="${WGET_CERTS} --no-check-certificate"
-BLACKHOLE="192.0.2.80" #Replace with the IP address of a stop page
-PARSER_OPTS="-i ${LIST_FILE} -o ${LIST_OUT} -f ${OUTPUT_FORMAT} -d ${LIST_TYPE} -b ${BLACKHOLE}"
+PARSER_OPTS="-i ${LIST_FILE} -o ${LIST_OUT} -f ${OUTPUT_FORMAT} -d ${LIST_TYPE} -b ${BLACKHOLE_CNCPO}"
 
 if [ ! -d "${TMP_DL_DIR}" ]
 then

--- a/src/update_manual.sh
+++ b/src/update_manual.sh
@@ -2,13 +2,16 @@
 
 . $(dirname "${0}")/censorship_params.sh
 
-LIST_FILE="${ROOT_DIR}/blacklist_manual.txt"
 LIST_OUT="${UNBOUND_CONF_DIR}/db.blacklist_manual.conf"
 LIST_TYPE="manuale"
 
-BLACKHOLE="127.0.0.1" #Replace with the chosen IP address
 PARSER_BIN="${ROOT_DIR}/censor_parser.py"
-PARSER_OPTS="-i ${LIST_FILE} -o ${LIST_OUT} -f ${OUTPUT_FORMAT} -d ${LIST_TYPE} -b ${BLACKHOLE}"
+PARSER_OPTS="-i ${MANUAL_LIST_FILE} -o ${LIST_OUT} -f ${OUTPUT_FORMAT} -d ${LIST_TYPE} -b ${BLACKHOLE_MANUAL}"
 
-##############################################################################
-${PARSER_BIN} ${PARSER_OPTS}
+if [ -f "${MANUAL_LIST_FILE}" ]
+then
+   ${PARSER_BIN} ${PARSER_OPTS}
+else
+    echo "No manual list file found, skipping."
+fi
+


### PR DESCRIPTION
We fixed the download of the AGCOM list. Now we download just the latest "Determina" from their website.

We centralized the blacklists IPs into the censorship_params.sh file and the path for the manual list.

We also introduced a check if the manual list file exists so that it doesn't throw an exception when it doesn't.

Added the processing of the AGCOM list in the update_blacklists.sh file.